### PR TITLE
Fixes text not displaying properly on contracts.

### DIFF
--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -56,39 +56,53 @@
 	var/datum/mind/owner
 	var/datum/antagonist/devil/devil_datum
 	icon_state = "paper_onfire"
+	var/contract_text = "This shouldn't be seen.  Error DEVIL:6"
+
+/obj/item/paper/contract/infernal/proc/create_text()
+	contract_text += "<i>["____________"]</i>"
+	src.add_raw_text(contract_text)
+	return
 
 /obj/item/paper/contract/infernal/power
 	name = "paper- contract for infernal power"
 	contractType = CONTRACT_POWER
+	contract_text = "<center><B>Contract for infernal power</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for power and physical strength.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/wealth
 	name = "paper- contract for unlimited wealth"
 	contractType = CONTRACT_WEALTH
+	contract_text = "<center><B>Contract for unlimited wealth</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for a pocket that never runs out of valuable resources.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/prestige
 	name = "paper- contract for prestige"
 	contractType = CONTRACT_PRESTIGE
+	contract_text = "<center><B>Contract for prestige</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for prestige and esteem among my peers.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/magic
 	name = "paper- contract for magical power"
 	contractType = CONTRACT_MAGIC
+	contract_text = "<center><B>Contract for magic</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for arcane abilities beyond normal human ability.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/revive
 	name = "paper- contract of resurrection"
 	contractType = CONTRACT_REVIVE
 	var/cooldown = FALSE
+	contract_text = "<center><B>Contract for resurrection</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for resurrection and curing of all injuries.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/knowledge
 	name = "paper- contract for knowledge"
 	contractType = CONTRACT_KNOWLEDGE
+	contract_text = "<center><B>Contract for knowledge</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for boundless knowledge.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/friend
 	name = "paper- contract for a friend"
 	contractType = CONTRACT_FRIEND
+	contract_text = "<center><B>Contract for a friend</B></center><BR><BR><BR>I, TARGET of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent DEVILNAME, in exchange for a friend.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/unwilling
 	name = "paper- infernal contract"
 	contractType = CONTRACT_UNWILLING
+	contract_text = "<center><B>Contract for slave</B></center><BR><BR><BR>I, TARGET, hereby offer my soul to the infernal hells by way of the infernal agent DEVILNAME.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
 
 /obj/item/paper/contract/infernal/Initialize(mapload, mob/living/nTarget, datum/mind/nOwner)
 	. = ..()
@@ -97,7 +111,9 @@
 	owner = nOwner
 	devil_datum = owner.has_antag_datum(/datum/antagonist/devil)
 	target = nTarget
-	update_text()
+	contract_text = replacetext(contract_text, "TARGET", "[target]") //KILL ME
+	contract_text = replacetext(contract_text, "DEVILNAME", "[devil_datum.truename]")
+	create_text()
 
 /obj/item/paper/contract/infernal/suicide_act(mob/living/user)
 	if(signed && (user == target.current) && istype(user, /mob/living/carbon/human/))
@@ -109,65 +125,6 @@
 		return(FIRELOSS)
 	else
 		..()
-
-/obj/item/paper/contract/infernal/update_text()
-	default_raw_text = "This shouldn't be seen.  Error DEVIL:6"
-
-/obj/item/paper/contract/infernal/power/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for infernal power</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for power and physical strength.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/wealth/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for unlimited wealth</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for a pocket that never runs out of valuable resources.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/prestige/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for prestige</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for prestige and esteem among my peers.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/magic/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for magic</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for arcane abilities beyond normal human ability.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/revive/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for resurrection</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for resurrection and curing of all injuries.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/knowledge/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for knowledge</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for boundless knowledge.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/friend/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for a friend</B></center><BR><BR><BR>I, [target] of sound mind, do hereby willingly offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename], in exchange for a friend.  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
-
-/obj/item/paper/contract/infernal/unwilling/update_text(signature = "____________", blood = 0)
-	default_raw_text = "<center><B>Contract for slave</B></center><BR><BR><BR>I, [target], hereby offer my soul to the infernal hells by way of the infernal agent [devil_datum.truename].  I understand that upon my demise, my soul shall fall into the infernal hells, and my body may not be resurrected, cloned, or otherwise brought back to life.  I also understand that this will prevent my brain from being used in an MMI.<BR><BR><BR>Signed, "
-	if(blood)
-		default_raw_text += "<font face=\"Nyala\" color=#600A0A size=6><i>[signature]</i></font>"
-	else
-		default_raw_text += "<i>[signature]</i>"
 
 /obj/item/paper/contract/infernal/attackby(obj/item/P, mob/living/carbon/human/user, params)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Refactors infernal contract subtype by ditching update_text which relies on deprecated methods to write text on a paper.
Now create_text handles writing the text by calling add_raw_text on src.

The strings have also been moved into their objects, as they are constant data. However I had to do a stupid workaround to get the target name and devil name to properly embedd into them at init by calling replacetext twice in a row using keywords. I hate this, but it works.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

On discord.

</details>

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
